### PR TITLE
BUG: Manually specify Git executable in the Docker test build

### DIFF
--- a/Docker/test.sh
+++ b/Docker/test.sh
@@ -15,5 +15,6 @@ cd /usr/src/SlicerITKUltrasound-build
 cmake \
   -DSlicer_DIR:PATH=/usr/src/Slicer-build/Slicer-build \
   -DBUILDNAME:STRING=Extension-SlicerITKUltrasound \
+  -DGIT_EXECUTABLE:FILEPATH=/usr/bin/git \
     /usr/src/SlicerITKUltrasound/
 ctest -VV -D Experimental


### PR DESCRIPTION
Addresses:

-- Setting default for EXTENSION_STATUS ........:
-- Found Git: /usr/bin/git
-- Found Subversion: /usr/bin/svn (found version "1.6.11")
CMake Error at
/usr/src/Slicer-build/VTKv7/CMake/NewCMake/FindPackageHandleStandardArgs.cmake:147
(message):
  Could NOT find Git (missing: GIT_EXECUTABLE)
  Call Stack (most recent call first):
  /usr/src/Slicer-build/VTKv7/CMake/NewCMake/FindPackageHandleStandardArgs.cmake:387 (_FPHSA_FAILURE_MESSAGE)
  /usr/src/Slicer/CMake/FindGit.cmake:175 (find_package_handle_standard_args)
  CMakeLists.txt:26 (find_package)
-- Configuring incomplete, errors occurred!