### PR TITLE
DOC: Use toctree maxdepth of 3 in Modules section

### DIFF
--- a/Documentation/source/Modules/index.rst
+++ b/Documentation/source/Modules/index.rst
@@ -4,6 +4,6 @@ Modules
 3D Slicer Modules:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    ScanConversion/index


### PR DESCRIPTION
This ensures that the actual scan conversion modules themselves are listed in
the toctree.

@jcfr This is a good improvement. Thanks for the suggestion :+1: 