### PR TITLE
DOC: Clarify that the extension currently performs scan conversion

### DIFF
--- a/Documentation/source/index.rst
+++ b/Documentation/source/index.rst
@@ -11,14 +11,14 @@ SlicerITKUltrasound
 .. image:: https://img.shields.io/github/stars/KitwareMedical/SlicerITKUltrasound.svg?style=social&label=Star
     :target: https://github.com/KitwareMedical/SlicerITKUltrasound
 
-A `3D Slicer`_ [Fedorov2012]_ extension for ultrasound image formation,
-processing, and analysis. Interfaces are built off the ITKUltrasound_ library
-[McCormick2014]_.  The modules available in this extension are useful for both
-2D and 3D image generation for traditional B-mode imaging [McCormick2010]_,
-but also next-generation ultrasound image modalities like ultrasound
-spectroscopy [Aylward2016]_, acoustic radiation force imaging (ARFI)
-[Palmeri2016]_, acoustic radiation force shear wave imaging (ARFI-SWEI), and
-others.
+A `3D Slicer`_ [Fedorov2012]_ extension for ultrasound image scan conversion
+of B-mode and next-generation ultrasound imaging modalities.  Interfaces are
+built off the ITKUltrasound_ library [McCormick2014]_.  The modules available
+in this extension are useful for both 2D and 3D image generation for
+traditional B-mode imaging [McCormick2010]_, but also next-generation
+ultrasound image modalities like ultrasound spectroscopy [Aylward2016]_,
+acoustic radiation force imaging (ARFI) [Palmeri2016]_, acoustic radiation
+force shear wave imaging (ARFI-SWEI), and others.
 
 
 Contents:

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ SlicerITKUltrasound
 .. image:: https://img.shields.io/github/stars/KitwareMedical/SlicerITKUltrasound.svg?style=social&label=Star
     :target: https://github.com/KitwareMedical/SlicerITKUltrasound
 
-A `3D Slicer <http://slicer.org/>`_ extension for ultrasound image formation, processing, and analysis. Interfaces built off the
+A `3D Slicer <http://slicer.org/>`_ extension for scan conversion of B-mode and next-generation ultrasound imaging modalities. Interfaces built off the
 `ITKUltrasound <https://github.com/KitwareMedical/ITKUltrasound/>`_ library.
 
 For more information, see the `project documentation

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'SlicerITKUltrasound: A 3D Slicer extension for ultrasound image formation, processing, and analysis'
+title: 'SlicerITKUltrasound: A 3D Slicer extension for scan conversion of B-mode and next-generation ultrasound imaging modalities'
 tags:
   - ultrasound
   - medical imaging
@@ -27,13 +27,11 @@ bibliography: paper.bib
 
 # Summary
 
-A 3D Slicer [@Fedorov2012] extension for ultrasound image formation,
-processing, and analysis. Interfaces are built off the ITKUltrasound library
-[@McCormick2014]. The modules available in this extension are useful for both
-2D and 3D image generation for traditional B-mode imaging [@McCormick2010],
-but also next-generation ultrasound image modalities like ultrasound
-spectroscopy [@Aylward2016], acoustic radiation force imaging (ARFI)
-[@Palmeri2016], acoustic radiation force shear wave imaging (ARFI-SWEI)
-[@Rosenzweig2014], and others.
+A 3D Slicer [@Fedorov2012] extension for ultrasound scan conversion during 2D
+and 3D image generation for traditional B-mode imaging [@McCormick2010], but
+also next-generation ultrasound image modalities like ultrasound spectroscopy
+[@Aylward2016], acoustic radiation force imaging (ARFI) [@Palmeri2016],
+acoustic radiation force shear wave imaging (ARFI-SWEI) [@Rosenzweig2014], and
+others.  Interfaces are built off the ITKUltrasound library [@McCormick2014].
 
 # References


### PR DESCRIPTION
The extension is currently used for scan conversion of pre-computed ARFI
images, etc. while image formation may be integrated in the future. Improve
the title and description so this is more clear.