### PR TITLE
COMP:  Remove SVN find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(EXTENSION_STATUS Beta)
 set(SUPERBUILD_TOPLEVEL_PROJECT SlicerITKUltrasound)
 
 find_package(Git REQUIRED)
-find_package(Subversion REQUIRED)
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
SVN is no longer used for Slicer builds