### PR TITLE
COMP:  Fix minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(SlicerITKUltrasound)
 


### PR DESCRIPTION
Required in ITKExternalModule: https://github.com/InsightSoftwareConsortium/ITK/blob/33be8eb7800f0458d1b52dd90c1652467f61fc71/CMake/ITKModuleExternal.cmake#L10